### PR TITLE
App context is now required in Flask-SQLAlchemy

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -36,5 +36,6 @@ def create_app():
 
 def create_database(app):
     if not path.exists('website/' + DB_NAME):
-        db.create_all(app=app)
+        with app.app_context():
+            db.create_all()
         print('Created Database!')


### PR DESCRIPTION
For newer versions of Flask-SQLAlchemy (>3.x I believe), app context is required when performing `db.create_all()` and other operations.

"You must be in an active Flask application context to execute queries and to access the session and engine."
See [https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/quickstart/](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/quickstart/)