### PR TITLE
updated onclick() parameter passing in javascript

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -5,7 +5,7 @@
   {% for note in user.notes %}
   <li class="list-group-item">
     {{ note.data }}
-    <button type="button" class="close" onClick="deleteNote({{ note.id }})">
+    <button type="button" class="close" onClick ="deleteNote('{{note.id}}')">
       <span aria-hidden="true">&times;</span>
     </button>
   </li>


### PR DESCRIPTION
on click event parameter passing formatted from 
` onClick ="deleteNote({{note.id}})" `
to
`onClick ="deleteNote('{{note.id}}')"` 
In Inline Javascript eventhandling is `onclickevent = "foo('parameter')" ` where parameter in this case should be inline variable block `{{ parametervalue }}`
now there's no "property assignment error"  or expected `','` error