### PR TITLE
Update auth.py - method='sha256' no longer supported

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -56,7 +56,7 @@ def sign_up():
             flash('Password must be at least 7 characters.', category='error')
         else:
             new_user = User(email=email, first_name=first_name, password=generate_password_hash(
-                password1, method='sha256'))
+                password1, method='pbkdf2:sha256'))
             db.session.add(new_user)
             db.session.commit()
             login_user(new_user, remember=True)


### PR DESCRIPTION
The generate_password_hash function using method='sha256' is unsupported now and generates an error, changing this to method='pbkdf2:sha256' fixes this error and works as expected.